### PR TITLE
fix(commands): tolerate non-string template from MCP-sourced commands

### DIFF
--- a/OpenCodeIOSClient/Models/OpenCodeModels.swift
+++ b/OpenCodeIOSClient/Models/OpenCodeModels.swift
@@ -1293,6 +1293,33 @@ struct OpenCodeCommand: Codable, Identifiable, Hashable, Sendable {
     var id: String { name }
 }
 
+extension OpenCodeCommand {
+    enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case agent
+        case model
+        case source
+        case template
+        case subtask
+        case hints
+    }
+
+    // opencode returns `template: {}` (an object) for MCP-sourced commands. Decode it
+    // leniently so one such command can't fail the entire `/command` response array.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        agent = try container.decodeIfPresent(String.self, forKey: .agent)
+        model = try container.decodeIfPresent(String.self, forKey: .model)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
+        template = (try? container.decode(String.self, forKey: .template)) ?? ""
+        subtask = try container.decodeIfPresent(Bool.self, forKey: .subtask)
+        hints = try container.decodeIfPresent([String].self, forKey: .hints) ?? []
+    }
+}
+
 struct OpenCodeComposerAttachment: Identifiable, Hashable, Sendable {
     enum Kind: String, Hashable, Sendable {
         case image

--- a/OpenCodeIOSClientTests/OpenCodeAPIClientTests.swift
+++ b/OpenCodeIOSClientTests/OpenCodeAPIClientTests.swift
@@ -102,6 +102,25 @@ final class OpenCodeAPIClientTests: XCTestCase {
         XCTAssertEqual(part.source?.end, 12)
     }
 
+    func testDecodesCommandsWhenMCPSourceReturnsObjectTemplate() throws {
+        // opencode returns `template: {}` for MCP-sourced commands; the whole `/command`
+        // array must still decode instead of failing with a DecodingError.typeMismatch.
+        let data = """
+        [
+          { "name": "init", "description": "Init", "source": "command", "template": "Create AGENTS.md", "hints": ["$ARGUMENTS"] },
+          { "name": "websearch:web_search_help", "description": "Get help with web search", "source": "mcp", "template": {}, "hints": [] }
+        ]
+        """.data(using: .utf8)!
+
+        let commands = try JSONDecoder().decode([OpenCodeCommand].self, from: data)
+
+        XCTAssertEqual(commands.count, 2)
+        XCTAssertEqual(commands[0].template, "Create AGENTS.md")
+        XCTAssertEqual(commands[1].name, "websearch:web_search_help")
+        XCTAssertEqual(commands[1].source, "mcp")
+        XCTAssertEqual(commands[1].template, "")
+    }
+
     func testListMessagesRepairsUnpairedUnicodeEscapesInToolOutput() async throws {
         let expectation = expectation(description: "request captured")
         let configuration = URLSessionConfiguration.ephemeral


### PR DESCRIPTION
Fixes #1 — decode `OpenCodeCommand.template` leniently so MCP-sourced commands returning `template: {}` no longer fail the entire `/command` array. Adds a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)