### PR TITLE
fix(live-activity): open and keep the chat for deep-linked sessions with no resolved project

### DIFF
--- a/OpenCodeIOSClient/ViewModels/AppViewModel/AppViewModel+LiveActivities.swift
+++ b/OpenCodeIOSClient/ViewModels/AppViewModel/AppViewModel+LiveActivities.swift
@@ -178,14 +178,7 @@ extension AppViewModel {
             guard isConnected else { return }
         }
 
-        let openedSession = await openLiveActivitySession(deepLink)
-        let resolvedDirectory = openedSession?.directory ?? deepLink.directory
-        if !isUsingAppleIntelligence, currentProject == nil || effectiveSelectedDirectory != resolvedDirectory {
-            await selectDirectory(resolvedDirectory)
-            if let openedSession {
-                await selectSession(openedSession)
-            }
-        }
+        await openLiveActivitySession(deepLink)
 
         switch deepLink.action {
         case .open:
@@ -231,6 +224,10 @@ extension AppViewModel {
 
     @discardableResult
     private func openLiveActivitySession(_ deepLink: LiveActivityDeepLink) async -> OpenCodeSession? {
+        if !isUsingAppleIntelligence, currentProject == nil || effectiveSelectedDirectory != deepLink.directory {
+            await selectDirectory(deepLink.directory)
+        }
+
         if session(matching: deepLink.sessionID) == nil {
             await ensureAllSessionsLoaded()
         }

--- a/OpenCodeIOSClient/ViewModels/AppViewModel/AppViewModel+LiveActivities.swift
+++ b/OpenCodeIOSClient/ViewModels/AppViewModel/AppViewModel+LiveActivities.swift
@@ -224,10 +224,6 @@ extension AppViewModel {
 
     @discardableResult
     private func openLiveActivitySession(_ deepLink: LiveActivityDeepLink) async -> OpenCodeSession? {
-        if !isUsingAppleIntelligence, currentProject == nil || effectiveSelectedDirectory != deepLink.directory {
-            await selectDirectory(deepLink.directory)
-        }
-
         if session(matching: deepLink.sessionID) == nil {
             await ensureAllSessionsLoaded()
         }
@@ -247,6 +243,11 @@ extension AppViewModel {
             activitySnapshot: activitySnapshot
         )
         let openedSession = resolution.session
+        let resolvedDirectory = openedSession.directory ?? deepLink.directory
+        if !isUsingAppleIntelligence, currentProject == nil || effectiveSelectedDirectory != resolvedDirectory {
+            await selectDirectory(resolvedDirectory)
+        }
+
         if case .fallback = resolution {
             upsertVisibleSession(openedSession)
         }

--- a/OpenCodeIOSClient/Views/Root/RootView.swift
+++ b/OpenCodeIOSClient/Views/Root/RootView.swift
@@ -162,6 +162,11 @@ struct RootView: View {
     }
 
     private func showCurrentRoute() {
+        if viewModel.selectedSession != nil {
+            showDetailColumn()
+            return
+        }
+
         guard viewModel.currentProject != nil else {
             showProjectSidebarIfNeeded()
             return

--- a/OpenCodeIOSClient/Views/Root/RootView.swift
+++ b/OpenCodeIOSClient/Views/Root/RootView.swift
@@ -126,6 +126,13 @@ struct RootView: View {
             }
         }
         .onChange(of: viewModel.selectedSession?.id) { _, sessionID in
+            if sessionID != nil {
+                withAnimation(opencodeSelectionAnimation) {
+                    showDetailColumn()
+                }
+                return
+            }
+
             guard viewModel.currentProject != nil else {
                 withAnimation(opencodeSelectionAnimation) {
                     columnVisibility = .all
@@ -134,15 +141,9 @@ struct RootView: View {
                 return
             }
 
-            if sessionID == nil {
-                withAnimation(opencodeSelectionAnimation) {
-                    columnVisibility = .doubleColumn
-                    preferredCompactColumn = .content
-                }
-            } else {
-                withAnimation(opencodeSelectionAnimation) {
-                    showDetailColumn()
-                }
+            withAnimation(opencodeSelectionAnimation) {
+                columnVisibility = .doubleColumn
+                preferredCompactColumn = .content
             }
         }
         .onChange(of: viewModel.currentProject?.id) { _, projectID in
@@ -170,7 +171,7 @@ struct RootView: View {
     }
 
     private func showProjectSidebarIfNeeded() {
-        guard viewModel.currentProject == nil else { return }
+        guard viewModel.currentProject == nil, viewModel.selectedSession == nil else { return }
 
         columnVisibility = .all
         preferredCompactColumn = .sidebar


### PR DESCRIPTION
## Problem

Opening a Live Activity deep link to a session that doesn't resolve to a
project — e.g. a global session (`projectID == "global"`) whose directory isn't
a registered project worktree — was unreliable: the chat would open and then
"jump back" to the Projects list, or not open at all, depending on the prior
navigation state (racy).

## Root cause

`RootView` gates showing the detail (chat) column on `currentProject != nil`, in
two places:

- when the selected session changes, it forces the project sidebar if
  `currentProject == nil`;
- when `currentProject` becomes `nil` (which can happen asynchronously after a
  directory reload/event), it forces the sidebar.

For a session that doesn't map to a project, `currentProject` is `nil` (or gets
reset shortly after), so the chat stays hidden behind the Projects sidebar even
though a session is selected.

Separately, the Live Activity flow selected the session first and switched the
directory afterwards — and switching a directory clears `selectedSession` —
causing a select → clear → re-select churn (a visible flicker).

## Fix

- **`RootView`**: a selected session always shows the chat, regardless of
  `currentProject`; a later `currentProject` reset no longer pops an open chat
  back to the project list.
- **`AppViewModel+LiveActivities`**: switch to the deep link's directory *before*
  selecting the session, so the selection is the final navigation action. Also
  removes a now-redundant second directory switch.

For the common case (`currentProject != nil`) the `RootView` behavior is
unchanged — only the `currentProject == nil` + selected-session case is affected,
which is exactly the broken path.

## Testing

Verified in the simulator against a live opencode server: deep links to global /
non-project-directory sessions open the chat and keep it, from any starting
screen (including the Projects list) and through the async window that previously
reset it. Navigation-adjacent unit tests (coordinators, stores, API client) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
